### PR TITLE
Check for both possibilities of TypeScript definitions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const normalizeNewline = require('normalize-newline')
 
 const FIELDS = [
   'bin',
-  'typings', // TypeScript
+  'types', // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html used by TypeScript
+  'typings', // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html alternatively used by TypeScript
   'module', // https://github.com/stereobooster/package.json#module used by rollup, webpack
   'es2015' // https://github.com/stereobooster/package.json#es2015 used by Angular
 ]


### PR DESCRIPTION
TypeScript can use either `types` _or_ `typings`. See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html