### PR TITLE
Relative path check #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,12 @@ function doesntExist (dir, file) {
   return !fs.existsSync(path.join(dir, file))
 }
 
-function mustBeRelative (file, key) {
+function mustBeRelative (field, file, key) {
   const mustBeRelative = ['browser']
 
-  if (!mustBeRelative.includes(key)) return
+  if (!mustBeRelative.includes(field)) return
 
-  return !file.match(/^.\//)
+  return !file.match(/^.\//) || (key && !key.match(/^.\//))
 }
 
 function checkField (pkg, dir, field) {
@@ -39,7 +39,7 @@ function checkField (pkg, dir, field) {
               content: `${field}.${key}`
             })
           }
-          if (mustBeRelative(pkg[field][key], key)) {
+          if (mustBeRelative(field, pkg[field][key], key)) {
             errors.push({
               type: 'needsRelativePath',
               content: `${field}.${key}`
@@ -53,7 +53,7 @@ function checkField (pkg, dir, field) {
           content: field
         })
       }
-      if (mustBeRelative(pkg[field], field)) {
+      if (mustBeRelative(field, pkg[field])) {
         errors.push({
           type: 'needsRelativePath',
           content: field
@@ -128,7 +128,7 @@ function pkgOk (dir, { fields = [], bin = [] } = {}) {
           err.push(`${content} path doesn't exist in package.json`)
         }
         if (type === 'needsRelativePath') {
-          err.push(`${content} must use a relative path`)
+          err.push(`${content} must use a relative path for value (and key when value is an object)`)
         }
         return err.reduce((mem, curr) => curr.concat(mem), [])
       })

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ function doesntExist (dir, file) {
 }
 
 function mustBeRelative (field, file, key) {
-  const mustBeRelative = ['browser']
+  const mustBeRelativeList = ['browser']
 
-  if (!mustBeRelative.includes(field)) return
+  if (!mustBeRelativeList.includes(field)) return
 
   return !file.match(/^.\//) || (key && !key.match(/^.\//))
 }

--- a/index.js
+++ b/index.js
@@ -26,12 +26,18 @@ function checkField (pkg, dir, field) {
         .keys(pkg[field])
         .forEach(key => {
           if (doesntExist(dir, pkg[field][key])) {
-            errors.push(`${field}.${key}`)
+            errors.push({
+              type: 'doesNotExist',
+              content: `${field}.${key}`
+            })
           }
         })
     } else {
       if (doesntExist(dir, pkg[field])) {
-        errors.push(field)
+        errors.push({
+          type: 'doesNotExist',
+          content: field
+        })
       }
     }
   }
@@ -44,7 +50,10 @@ function checkFields (pkg, dir, otherFields) {
 
   // https://docs.npmjs.com/files/package.json#main
   if (pkg.main && doesntExist(dir, pkg.main)) {
-    errors.push('main')
+    errors.push({
+      type: 'doesNotExist',
+      content: 'main'
+    })
   }
 
   const fields = FIELDS.concat(otherFields || [])
@@ -93,7 +102,11 @@ function pkgOk (dir, { fields = [], bin = [] } = {}) {
 
   if (errors.length) {
     const message = errors
-      .map(error => `${error} path doesn't exist in package.json`)
+      .map(({ type, content }) => {
+        switch (type) {
+          case 'doesNotExist': return `${content} path doesn't exist in package.json`
+        }
+      })
       .join('\n')
 
     throw new Error(message)

--- a/index.test.js
+++ b/index.test.js
@@ -34,14 +34,29 @@ describe('pkg-ok', () => {
         bin: 'script.js'
       }),
       '/E/script.js': 'foo\r\nbar',
-      '/E/another-script.js': 'baz\r\nqux'
+      '/E/another-script.js': 'baz\r\nqux',
+      '/F/package.json': JSON.stringify({
+        'browser': {
+          './dist/lib.cjs.js': './dist/lib.cjs.browser.js',
+          './dist/lib.esm.js': './dist/lib.esm.browser.js'
+        }
+      }),
+      '/F/dist/lib.cjs.browser.js': 'cjs',
+      '/F/dist/lib.esm.browser.js': 'esm',
+      '/G/package.json': JSON.stringify({
+        'browser': {
+          'dist/lib.cjs.js': './dist/lib.cjs.browser.js',
+          './dist/lib.esm.js': 'dist/lib.esm.browser.js'
+        }
+      }),
+      '/G/dist/lib.cjs.js': './dist/lib.cjs.browser.js'
     })
   })
 
   afterEach(() => mock.restore())
 
   it('checks /A', () => {
-    expect(() => pkgOk(path.join('/A'))).toThrowError(/main[\s\S]*bin[\s\S]*types[\s\S]*typings[\s\S]*module[\s\S]*es2015[\s\S]*browser/)
+    expect(() => pkgOk(path.join('/A'))).toThrowError(/main[\s\S]*bin[\s\S]*types[\s\S]*typings[\s\S]*module[\s\S]*es2015[\s\S]*browser path[\s\S]*browser must/)
   })
 
   it('checks /B', () => {
@@ -60,5 +75,14 @@ describe('pkg-ok', () => {
     pkgOk(path.join('/E'), { bin: ['another-script.js'] })
     expect(fs.readFileSync('/E/script.js', 'utf-8')).toEqual('foo\nbar')
     expect(fs.readFileSync('/E/another-script.js', 'utf-8')).toEqual('baz\nqux')
+  })
+
+  it('checks /F', () => {
+    pkgOk(path.join('/F'))
+    expect(fs.readFileSync('/F/dist/lib.cjs.browser.js', 'utf-8')).toEqual('cjs')
+    expect(fs.readFileSync('/F/dist/lib.esm.browser.js', 'utf-8')).toEqual('esm')
+  })
+  it('checks /G', () => {
+    expect(() => pkgOk(path.join('/G'))).toThrowError(/browser.*path[\s\S]*browser.*must[\s\S]*browser.*path[\s\S]*browser.*must/)
   })
 })


### PR DESCRIPTION
Hopefully this resolves #9  the issue!

An error will now be added to the message being thrown if value and/or key of the browser field are not relative (beginning with `./`)

To do this I needed to modify the error array to be an array of objects with form 

```js 
{
  type: [cause], 
  content: [error info]
}
```

If any other fields need to be checked for relative path, this functionality can be extended by adding the field to the `mustBeRelativeList` array